### PR TITLE
upgrade GitHub workflow with new syntax

### DIFF
--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -13,7 +13,7 @@ jobs:
             - name: Get npm cache directory
               id: npm-cache
               run: |
-                  echo "::set-output name=dir::$(npm config get cache)"
+                  echo "dir=$(npm config get cache)" >> $GITHUB_OUTPUT
             - uses: actions/cache@v2
               with:
                   path: |


### PR DESCRIPTION
because set-output has been deprecated
https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/



---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1204547419615992